### PR TITLE
Use type_formatters to format datetime (if specified)

### DIFF
--- a/holocube/element/util.py
+++ b/holocube/element/util.py
@@ -2,9 +2,17 @@ from iris.util import guess_coord_axis
 from holoviews.core.dimension import Dimension
 from holoviews.core.util import * # noqa (API import)
 
+import datetime
+
 def get_date_format(coord):
     def date_formatter(val, pos=None):
-        return coord.units.num2date(val)
+        date = coord.units.num2date(val)
+        date_format = Dimension.type_formatters.get(datetime.datetime, None)
+        if date_format:
+            return date.strftime(date_format)
+        else:
+            return date
+
     return date_formatter
 
 def coord_to_dimension(coord):


### PR DESCRIPTION
This PR gives a bit more flexibility when formatting dates by allowing a format string to be set as the formatter for `datetime.datetime` objects. For instance you can now do:

``` python
import datetime
hv.Dimension.type_formatters[datetime.datetime] = "%m/%y %Hh"
```
